### PR TITLE
Sim bindings for trajectory tracing

### DIFF
--- a/python/rcsss/_core/sim.pyi
+++ b/python/rcsss/_core/sim.pyi
@@ -10,18 +10,12 @@ __all__ = ["FR3", "FR3Config", "FR3State"]
 
 class FR3(rcsss._core.common.Robot):
     def __init__(self, mjmdl: str, rlmdl: str, render: bool | None) -> None: ...
-<<<<<<< HEAD
     def clear_markers(self) -> None: ...
 
 class FR3Config(rcsss._core.common.RConfig):
     ik_duration: int
     realtime: bool
     trajectory_trace: bool
-=======
-
-class FR3Config(rcsss._core.common.RConfig):
-    ik_duration: int
->>>>>>> master
 
 class FR3State(rcsss._core.common.RState):
     def __init__(self) -> None: ...

--- a/src/pybind/rcsss.cpp
+++ b/src/pybind/rcsss.cpp
@@ -302,7 +302,8 @@ PYBIND11_MODULE(_core, m) {
   py::class_<rcs::sim::FR3Config, rcs::common::RConfig>(sim, "FR3Config")
       .def_readwrite("ik_duration", &rcs::sim::FR3Config::ik_duration)
       .def_readwrite("realtime", &rcs::sim::FR3Config::realtime)
-      .def_readwrite("trajectory_trace", &rcs::sim::FR3Config::trajectory_trace);
+      .def_readwrite("trajectory_trace",
+                     &rcs::sim::FR3Config::trajectory_trace);
   py::class_<rcs::sim::FR3State, rcs::common::RState>(sim, "FR3State")
       .def(py::init<>())
       .def_readonly("collision", &rcs::sim::FR3State::collision)


### PR DESCRIPTION
bindings for `clear_markers`
config struct includes `realtime` and `trajectory_trace`
