### PR TITLE
feat(unittests): inital setup for unittests

### DIFF
--- a/python/rcsss/tests/unittests/test_common.py
+++ b/python/rcsss/tests/unittests/test_common.py
@@ -1,0 +1,28 @@
+import pytest
+from rcsss import common
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    "initial_pose, destination_pose, progress, expected_pose_matrix",
+    [
+        [
+            np.array([[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]),
+            np.array([[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]),
+            1.0,
+            np.array(
+                [
+                    [-0.33333333, 0.66666667, 0.66666667, 1],
+                    [0.66666667, -0.33333333, 0.66666667, 1.0],
+                    [0.66666667, 0.66666667, -0.33333333, 1.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+        ]
+    ],
+)
+def test_interpolate(initial_pose, destination_pose, progress, expected_pose_matrix):
+    start_pose = common.Pose(initial_pose)
+    end_pose = common.Pose(destination_pose)
+    result = start_pose.interpolate(end_pose, progress=progress)
+    assert np.allclose(result.pose_matrix(), expected_pose_matrix)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ mypy==1.4.1
 types-requests~=2.31
 pybind11-stubgen==2.5
 build
+pytest==8.1.1


### PR DESCRIPTION
- initial directory setup for unittests
- wrote a dummy test for pose Interpolation method

This PR is for discussing the suitability of the proposed structure for writing unittests hereon. The initial small test written for pose interpolation is just to test the setup and is not a meaningful test yet, so we can just close the PR after discussing.
I want to get your thoughts on the following aspects:
1. Usage
    Just the command 'pytest' on the repo directory would fetch and run all the tests and display the result, this command   can easily be added to the workflow.

2. location of the test scripts
    we can either have a standalone directory in the repo root directory or have test directories in each component of the python code(similar to how it is implemented now)

3. Any other things that need to be considered?
