### PR TITLE
Fix cmake instability finding python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ FetchContent_Declare(pybind11
     EXCLUDE_FROM_ALL
 )
 
+set(PYBIND11_FINDPYTHON True)
 FetchContent_MakeAvailable(libfranka rl pybind11)
 
 find_package(Eigen3 REQUIRED)

--- a/src/sim/CMakeLists.txt
+++ b/src/sim/CMakeLists.txt
@@ -1,4 +1,5 @@
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+include(FindPython)
+find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(glfw3 REQUIRED)
 set(MUJOCO_DIR ${Python_SITELIB}/mujoco)
 set(MODEL_DIR ${CMAKE_SOURCE_DIR}/models)


### PR DESCRIPTION
Cmake was not reliably finding the venv sitelib dir. After building the pip package and then reconfiguring with cmake (`cmake -B build`), cmake would find sitelib in `/usr/lib/python3/`, where the mujoco package would be missing. The reason and fix for this is documented in the [pybind docs](https://pybind11.readthedocs.io/en/stable/faq.html#inconsistent-detection-of-python-version-in-cmake-and-pybind11)