### PR TITLE
fix(cpp): replace isapprox comperison

### DIFF
--- a/src/common/Pose.cpp
+++ b/src/common/Pose.cpp
@@ -177,7 +177,7 @@ Pose Pose::inverse() const {
 }
 
 bool Pose::is_close(const Pose &other, double eps_r, double eps_t) const {
-  return (this->translation() - other.translation()).norm() < eps_t &&
+  return (this->translation() - other.translation()).lpNorm<1>() < eps_t &&
          this->quaternion().angularDistance(other.quaternion()) < eps_r;
 }
 

--- a/src/common/Pose.h
+++ b/src/common/Pose.h
@@ -55,7 +55,7 @@ struct RPY {
   }
 
   bool is_close(const RPY &other, double eps = 1e-8) const {
-    return this->as_vector().isApprox(other.as_vector(), eps);
+    return (this->as_vector() - other.as_vector()).lpNorm<1>() < eps;
   }
 };
 

--- a/src/sim/FR3.cpp
+++ b/src/sim/FR3.cpp
@@ -187,15 +187,18 @@ void FR3::set_cartesian_position(const common::Pose& pose) {
 }
 void FR3::is_moving_callback() {
   common::Vector7d current_angles = this->get_joint_position();
-  this->state.is_moving = not this->state.previous_angles.isApprox(
-      current_angles, 0.0001);  // TODO: careful with isapprox
+  // difference of the largest element is smaller than threshold
+  this->state.is_moving =
+      (current_angles - this->state.previous_angles).cwiseAbs().maxCoeff() >
+      0.0001;
   this->state.previous_angles = current_angles;
 }
 
 void FR3::is_arrived_callback() {
   common::Vector7d current_angles = this->get_joint_position();
-  this->state.is_arrived = this->state.target_angles.isApprox(
-      current_angles, this->cfg.joint_rotational_tolerance);
+  this->state.is_arrived =
+      (current_angles - this->state.target_angles).cwiseAbs().maxCoeff() <
+      this->cfg.joint_rotational_tolerance;
 }
 
 bool FR3::collision_callback() {


### PR DESCRIPTION
According to the eigen documentation isApprox does not work for comparisons with another vector close to zero. That is why this commit changes it to l1 norm comparisons.

The FR3 moving and arriving callbacks are performed on the l infinite norm (absolute max element).