### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,16 @@ sudo apt install $(cat debian_deps.txt)
 ```shell
 python3 -m venv .venv
 source .venv/bin/activate
-pip config --site set global.no-build-isolation false
 pip install -r requirements_dev.txt
+pip config --site set global.no-build-isolation false
+```
+2.5 (optional) include UTN models if you have an access token
+```shell
+pip config --site set install.config-settings "cmake.args=-DINCLUDE_UTN_MODELS=ON;-DGITLAB_MODELS_TOKEN=<token>"
 ```
 3. Build and install RCS:
 ```shell
 pip install -ve .
-```
-
-### UTN Models
-If you have a token to download the UTN models, you can add them to the pip package using:
-```shell
-pip install --config-settings=cmake.define.INCLUDE_UTN_MODELS=ON --config-settings=cmake.define.GITLAB_MODELS_TOKEN=<token> -ve .
 ```
 
 ## Usage


### PR DESCRIPTION
configuring pip to include the token and INCLUDE_UTN_MODELS command line argument is more robust. If the build folder is deleted, you don't need to use the long pip install --config-settings ... etc. command