### PR TITLE
docs: clean up docs structure and navigation

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,10 +1,5 @@
-# API
+# API Reference
 
-```{toctree}
-:maxdepth: 2
+The API reference is automatically generated from the source code.
 
-../getting_started/index
-../user_guide/architecture
-../user_guide/gym_interface
-../user_guide/low_level_api
-```
+(Coming soon)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,10 @@
-# API Reference
+# API
 
-The API reference is automatically generated from the source code.
+```{toctree}
+:maxdepth: 2
 
-(Coming soon)
+../getting_started/index
+../user_guide/architecture
+../user_guide/gym_interface
+../user_guide/low_level_api
+```

--- a/docs/extensions/rcs_fr3.md
+++ b/docs/extensions/rcs_fr3.md
@@ -32,8 +32,8 @@ ROBOT_IP = "172.16.0.2" # Replace with your robot IP
 
 user, pw = load_creds_franka_desk()
 with FCI(Desk(ROBOT_IP, user, pw), unlock=False, lock_when_done=False):
-    urdf_path = rcs.scenes["fr3_empty_world"].urdf
-    ik = rcs.common.RL(str(urdf_path))
+    robot_meta = rcs.ROBOTS[rcs.common.RobotType.FR3]
+    ik = rcs.common.Pin(robot_meta.mjcf_model_path, robot_meta.attachment_site)
     
     # Configure Robot
     robot = hw.Franka(ROBOT_IP, ik)

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -53,19 +53,17 @@ from time import sleep
 import numpy as np
 
 # Load simulation scene
-simulation = sim.Sim(rcs.scenes["fr3_empty_world"].mjb)
-urdf_path = rcs.scenes["fr3_empty_world"].urdf
-ik = rcs.common.RL(str(urdf_path))
+robot_meta = rcs.ROBOTS[rcs.common.RobotType.FR3]
+simulation = sim.Sim(rcs.SCENE_PATHS["empty_world"])
+ik = rcs.common.Pin(robot_meta.mjcf_model_path, robot_meta.attachment_site)
 
 # Configure robot
 cfg = sim.SimRobotConfig()
-cfg.add_postfix("_0")
 cfg.tcp_offset = rcs.common.Pose(rcs.common.FrankaHandTCPOffset())
 robot = rcs.sim.SimRobot(simulation, ik, cfg)
 
 # Configure gripper
 gripper_cfg_sim = sim.SimGripperConfig()
-gripper_cfg_sim.add_postfix("_0")
 gripper = sim.SimGripper(simulation, gripper_cfg_sim)
 
 # Configure cameras
@@ -93,24 +91,16 @@ input("press enter to close")
 RCS provides a high-level [Gymnasium](https://gymnasium.farama.org/) interface for Reinforcement Learning and general control.
 
 ```python
-from rcs.envs.creators import SimEnvCreator
-from rcs.envs.utils import (
-    default_mujoco_cameraset_cfg,
-    default_sim_gripper_cfg,
-    default_sim_robot_cfg,
-)
 from rcs.envs.base import ControlMode, RelativeTo
+from rcs.envs.configs import EmptyWorldFR3
 import numpy as np
 
-# Create environment
-env_rel = SimEnvCreator()(
-    control_mode=ControlMode.JOINTS,
-    robot_cfg=default_sim_robot_cfg(),
-    gripper_cfg=default_sim_gripper_cfg(),
-    cameras=default_mujoco_cameraset_cfg(),
-    max_relative_movement=np.deg2rad(5),
-    relative_to=RelativeTo.LAST_STEP,
-)
+scene = EmptyWorldFR3()
+cfg = scene.config()
+cfg.control_mode = ControlMode.JOINTS
+cfg.max_relative_movement = np.deg2rad(5)
+cfg.relative_to = RelativeTo.LAST_STEP
+env_rel = scene.create_env(cfg)
 
 # Open GUI
 env_rel.get_wrapper_attr("sim").open_gui()
@@ -129,8 +119,8 @@ for _ in range(100):
 ## Examples
 
 Check out the python examples in the `examples` folder of the repository.
-- `examples/fr3/fr3_direct_control.py`: Direct robot control with RCS's python bindings.
-- `examples/fr3/fr3_env_joint_control.py`: Gymnasium interface with joint control.
-- `examples/fr3/fr3_env_cartesian_control.py`: Gymnasium interface with Cartesian control.
+- `fr3_direct_control.py`: Direct robot control with RCS's python bindings.
+- `fr3_env_joint_control.py`: Gymnasium interface with joint control.
+- `fr3_env_cartesian_control.py`: Gymnasium interface with Cartesian control.
 
 Most examples work both in the MuJoCo simulation as well as on hardware (with appropriate extensions installed).

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -129,8 +129,8 @@ for _ in range(100):
 ## Examples
 
 Check out the python examples in the `examples` folder of the repository.
-- `fr3_direct_control.py`: Direct robot control with RCS's python bindings.
-- `fr3_env_joint_control.py`: Gymnasium interface with joint control.
-- `fr3_env_cartesian_control.py`: Gymnasium interface with Cartesian control.
+- `examples/fr3/fr3_direct_control.py`: Direct robot control with RCS's python bindings.
+- `examples/fr3/fr3_env_joint_control.py`: Gymnasium interface with joint control.
+- `examples/fr3/fr3_env_cartesian_control.py`: Gymnasium interface with Cartesian control.
 
 Most examples work both in the MuJoCo simulation as well as on hardware (with appropriate extensions installed).

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,14 @@
 
 ```{toctree}
 :maxdepth: 2
+:caption: User Guide
+
+getting_started/index
+user_guide/index
+```
+
+```{toctree}
+:maxdepth: 2
 :caption: API
 
 api/index

--- a/docs/user_guide/gym_interface.md
+++ b/docs/user_guide/gym_interface.md
@@ -4,29 +4,32 @@ The high-level interface of RCS is based on [Gymnasium](https://gymnasium.farama
 
 ## Environment Creation
 
-To facilitate environment creation, RCS ships with environment factory classes that create an envrionment already wrapped with the most common wrappers.
-Simulated environments are created using the `SimEnvCreator`.
+To facilitate environment creation, RCS ships with config-based creator classes that return environments already wrapped with the most common wrappers.
+Simulated environments are typically created through a scene config class such as `EmptyWorldFR3`.
 
 ```python
-from rcs.envs.creators import SimEnvCreator
-from rcs.envs.base import ControlMode
+from rcs.envs.base import ControlMode, RelativeTo
+from rcs.envs.configs import EmptyWorldFR3
 
-env = SimEnvCreator()(
-    control_mode=ControlMode.JOINTS,
-    # ... configuration objects ...
-)
+scene = EmptyWorldFR3()
+cfg = scene.config()
+cfg.control_mode = ControlMode.JOINTS
+cfg.relative_to = RelativeTo.LAST_STEP
+env = scene.create_env(cfg)
 ```
 
-Hardware environments are created using the robot-specific environment creator functions, located in the hardware extensions, usually named `<RobotName>EnvCreator`.
+Hardware environments are created using the robot-specific config creators and default config classes from the hardware extensions.
 ```python
-from rcs_fr3.creators import RCSFR3EnvCreator
-from rcs.envs.base import ControlMode
+from rcs.envs.base import ControlMode, RelativeTo
+from rcs_fr3.configs import DefaultFR3HardwareEnv
 
-env = RCSFR3EnvCreator()(
-    ip="192.168.100.1",
-    control_mode=ControlMode.JOINTS,
-    # ... configuration objects ...
-)
+creator = DefaultFR3HardwareEnv()
+creator.ip = "192.168.100.1"
+cfg = creator.config()
+cfg.control_mode = ControlMode.JOINTS
+cfg.camera_cfgs = None
+cfg.relative_to = RelativeTo.LAST_STEP
+env = creator.create_env(cfg)
 ```
 
 

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -1,0 +1,11 @@
+# User Guide
+
+The User Guide provides in-depth information about the core concepts and components of the Robot Control Stack.
+
+```{toctree}
+:maxdepth: 2
+
+architecture
+gym_interface
+low_level_api
+```


### PR DESCRIPTION
## Summary
- clean up the docs structure and toctree organization
- add the missing user guide index and improve navigation paths
- fix stale docs references and related structural drift

## Validation
- sphinx-build -b html docs docs/_build/html

This is the first PR in a stacked docs update.