### PR TITLE
fix robotiq hardware not found

### DIFF
--- a/extensions/rcs_ur5e/src/rcs_ur5e/creators.py
+++ b/extensions/rcs_ur5e/src/rcs_ur5e/creators.py
@@ -87,7 +87,7 @@ def _create_robotiq_gripper(cfg: GripperConfig) -> Gripper:
 
 
 HARDWARE_GRIPPER_CREATORS: dict[str, typing.Callable[[GripperConfig], Gripper]] = {
-    "Robotiq2F85siemens": _create_robotiq_gripper,
+    "Robotiq2F85": _create_robotiq_gripper,
 }
 
 


### PR DESCRIPTION
Fix error when using real UR5e with Robotiq Gripper: ValueError: Unknown hardware gripper type id: Robotiq2F85