### PR TITLE
Feat: clearer naming convention for init-level dicts GRIPPER_OFFSETS

### DIFF
--- a/examples/taxim/grasp_digit_demo.py
+++ b/examples/taxim/grasp_digit_demo.py
@@ -23,11 +23,11 @@ def _progress(iterable):
 class PickUpDemo:
     def __init__(self, env: gym.Env):
         self.env = env
-        self._robot = cast(SimRobot, self.env.get_wrapper_attr("robot")["robot"])
+        self._robot = cast(SimRobot, self.env.get_wrapper_attr("robot")["right"])
         self.home_pose = self._robot.get_cartesian_position()
 
     def _action(self, pose: Pose, gripper: list[float]) -> dict[str, Any]:
-        return {"robot": {"xyzrpy": pose.xyzrpy(), "gripper": gripper}}
+        return {"right": {"xyzrpy": pose.xyzrpy(), "gripper": gripper}}
 
     def get_object_pose(self, geom_name: str) -> Pose:
         model = self.env.get_wrapper_attr("sim").model

--- a/extensions/rcs_fr3/src/rcs_fr3/configs.py
+++ b/extensions/rcs_fr3/src/rcs_fr3/configs.py
@@ -119,7 +119,7 @@ class DROIDEnv(RCSFR3MultiConfigEnvCreator):
         cfg = base.config()
         cfg.robot_cfg.async_control = True
         cfg.robot_cfg.ip = self.robot_ip
-        cfg.robot_cfg.tcp_offset = rcs.GRIPPER_OFFSETS[common.GripperType("Robotiq2F85")]
+        cfg.robot_cfg.tcp_offset = rcs.GRIPPER_TCP_OFFSETS[common.GripperType("Robotiq2F85")]
         cfg.robot_cfg.q_home = rcs.HOME_POSITIONS["FR3_DROID"]
 
         return FR3MultiHardwareEnvCreatorConfig(
@@ -209,8 +209,8 @@ class FrankaDuoEnv(DefaultFR3DualMultiHardwareEnv):
 
         cfg = super().config()
         cfg.camera_cfgs = None
-        cfg.robot_cfgs["left"].tcp_offset = rcs.GRIPPER_OFFSETS[common.GripperType("Robotiq2F85")]
-        cfg.robot_cfgs["right"].tcp_offset = rcs.GRIPPER_OFFSETS[common.GripperType("Robotiq2F85")]
+        cfg.robot_cfgs["left"].tcp_offset = rcs.GRIPPER_TCP_OFFSETS[common.GripperType("Robotiq2F85")]
+        cfg.robot_cfgs["right"].tcp_offset = rcs.GRIPPER_TCP_OFFSETS[common.GripperType("Robotiq2F85")]
         cfg.robot_cfgs["left"].q_home = rcs.HOME_POSITIONS["FR3_DUO_LEFT"]
         cfg.robot_cfgs["right"].q_home = rcs.HOME_POSITIONS["FR3_DUO_RIGHT"]
         cfg.gripper_cfgs = {

--- a/extensions/rcs_panda/src/rcs_panda/configs.py
+++ b/extensions/rcs_panda/src/rcs_panda/configs.py
@@ -60,7 +60,7 @@ class DROIDEnv(RCSPandaMultiConfigEnvCreator):
         cfg = base.config()
         cfg.robot_cfg.async_control = True
         cfg.robot_cfg.ip = self.robot_ip
-        cfg.robot_cfg.tcp_offset = rcs.GRIPPER_OFFSETS[common.GripperType("Robotiq2F85")]
+        cfg.robot_cfg.tcp_offset = rcs.GRIPPER_TCP_OFFSETS[common.GripperType("Robotiq2F85")]
         cfg.robot_cfg.q_home = rcs.ROBOTS[RobotType.Panda].q_home
 
         return PandaMultiHardwareEnvCreatorConfig(

--- a/extensions/rcs_taxim/src/rcs_taxim/creators.py
+++ b/extensions/rcs_taxim/src/rcs_taxim/creators.py
@@ -84,6 +84,7 @@ class FR3TaximSimplePickUpSimEnvCreator:
 
         scene = EmptyWorldFR3()
         cfg = scene.config()
+        cfg.robot_cfgs["right"].tcp_offset = rcs.GRIPPER_OFFSETS[rcs.common.GripperType("Robotiq2F85")]
         cfg.control_mode = control_mode
         cfg.headless = render_mode != "human"
         cfg.sim_cfg.realtime = render_mode == "human"
@@ -97,8 +98,8 @@ class FR3TaximSimplePickUpSimEnvCreator:
         cfg.relative_to = RelativeTo.LAST_STEP if delta_actions else RelativeTo.NONE
         if not delta_actions:
             cfg.max_relative_movement = None
-        cfg.gripper_cfgs = {"robot": _taxim_gripper_cfg()}
-        cfg.gripper_offsets = None
+        cfg.gripper_cfgs = {"right": _taxim_gripper_cfg()}
+        cfg.gripper_offsets = {"right": rcs.DEFAULT_TRANSFORMS["FR3_ROBOTIQ_GRIPPER"]}
         cfg.root_frame_objects = {
             "": (
                 rcs.OBJECT_PATHS["green_cube"],

--- a/extensions/rcs_taxim/src/rcs_taxim/creators.py
+++ b/extensions/rcs_taxim/src/rcs_taxim/creators.py
@@ -84,7 +84,7 @@ class FR3TaximSimplePickUpSimEnvCreator:
 
         scene = EmptyWorldFR3()
         cfg = scene.config()
-        cfg.robot_cfgs["right"].tcp_offset = rcs.GRIPPER_OFFSETS[rcs.common.GripperType("Robotiq2F85")]
+        cfg.robot_cfgs["right"].tcp_offset = rcs.GRIPPER_TCP_OFFSETS[rcs.common.GripperType("Robotiq2F85")]
         cfg.control_mode = control_mode
         cfg.headless = render_mode != "human"
         cfg.sim_cfg.realtime = render_mode == "human"
@@ -99,7 +99,7 @@ class FR3TaximSimplePickUpSimEnvCreator:
         if not delta_actions:
             cfg.max_relative_movement = None
         cfg.gripper_cfgs = {"right": _taxim_gripper_cfg()}
-        cfg.gripper_offsets = {"right": rcs.DEFAULT_TRANSFORMS["FR3_ROBOTIQ_GRIPPER"]}
+        cfg.gripper_offsets = {"right": rcs.GRIPPER_MOUNT_OFFSETS[rcs.common.GripperType("Robotiq2F85")]}
         cfg.root_frame_objects = {
             "": (
                 rcs.OBJECT_PATHS["green_cube"],

--- a/python/rcs/__init__.py
+++ b/python/rcs/__init__.py
@@ -196,8 +196,12 @@ GRIPPER_TCP_OFFSETS: dict[common.GripperType, common.Pose] = {
 }
 
 GRIPPER_MOUNT_OFFSETS: dict[common.GripperType, common.Pose] = {
-    common.GripperType.FrankaHand: common.Pose(rotation=common.FrankaHandTCPOffset()[:3, :3], translation=np.array([0.0, 0.0, 0.0])),
-    common.GripperType("Robotiq2F85"): common.Pose(translation=np.array([0.0, 0.0, 0.0]), quaternion=np.array([0.0, 0.0, 0.7071068, 0.7071068])),
+    common.GripperType.FrankaHand: common.Pose(
+        rotation=common.FrankaHandTCPOffset()[:3, :3], translation=np.array([0.0, 0.0, 0.0])
+    ),
+    common.GripperType("Robotiq2F85"): common.Pose(
+        translation=np.array([0.0, 0.0, 0.0]), quaternion=np.array([0.0, 0.0, 0.7071068, 0.7071068])
+    ),
 }
 
 SCENE_PATHS: dict[str, str] = {"empty_world": "assets/scenes/empty_world/scene.xml"}

--- a/python/rcs/__init__.py
+++ b/python/rcs/__init__.py
@@ -190,9 +190,14 @@ GRIPPER_PATHS: dict[common.GripperType, str] = {
     common.GripperType("Robotiq2F85"): "assets/grippers/robotiq_2f85/robotiq_2f85.xml",
 }
 
-GRIPPER_OFFSETS: dict[common.GripperType, common.Pose] = {
+GRIPPER_TCP_OFFSETS: dict[common.GripperType, common.Pose] = {
     common.GripperType.FrankaHand: common.Pose(pose_matrix=common.FrankaHandTCPOffset()),
     common.GripperType("Robotiq2F85"): common.Pose(translation=np.array([0, 0.0, 0.1493])),
+}
+
+GRIPPER_MOUNT_OFFSETS: dict[common.GripperType, common.Pose] = {
+    common.GripperType.FrankaHand: common.Pose(rotation=common.FrankaHandTCPOffset()[:3, :3], translation=np.array([0.0, 0.0, 0.0])),
+    common.GripperType("Robotiq2F85"): common.Pose(translation=np.array([0.0, 0.0, 0.0]), quaternion=np.array([0.0, 0.0, 0.7071068, 0.7071068])),
 }
 
 SCENE_PATHS: dict[str, str] = {"empty_world": "assets/scenes/empty_world/scene.xml"}
@@ -212,9 +217,6 @@ CAMERA_PATHS: dict[str, str] = {
 TASKS: dict[str, Any] = {}
 
 DEFAULT_TRANSFORMS = {
-    "FR3_ROBOTIQ_GRIPPER": common.Pose(
-        translation=np.array([0.0, 0.0, 0.0]), quaternion=np.array([0.0, 0.0, 0.7071068, 0.7071068])
-    ),
     "FR3_ROBOTIQ_WRIST_D405_MOUNT": common.Pose(
         translation=np.array([0.0, 0.0, 0.0]), quaternion=np.array([0.0, 0.0, 0.7071068, 0.7071068])
     ),

--- a/python/rcs/envs/configs.py
+++ b/python/rcs/envs/configs.py
@@ -24,7 +24,8 @@ import rcs
 from rcs import (
     CAMERA_PATHS,
     DEFAULT_TRANSFORMS,
-    GRIPPER_OFFSETS,
+    GRIPPER_TCP_OFFSETS,
+    GRIPPER_MOUNT_OFFSETS,
     OBJECT_PATHS,
     SCENE_PATHS,
 )
@@ -39,7 +40,7 @@ class EmptyWorldFR3(SimEnvCreator):
         q_home[-1] = np.pi / 4
         robot_cfg: SimRobotConfig[Literal[7]] = SimRobotConfig(
             robot_type=RobotType.FR3,
-            tcp_offset=GRIPPER_OFFSETS[rcs.common.GripperType.FrankaHand],
+            tcp_offset=GRIPPER_TCP_OFFSETS[rcs.common.GripperType.FrankaHand],
             attachment_site=rcs.ROBOTS[RobotType.FR3].attachment_site,
             kinematic_model_path=rcs.ROBOTS[RobotType.FR3].mjcf_model_path,
             joint_rotational_tolerance=0.05 * (np.pi / 180.0),
@@ -153,9 +154,7 @@ class EmptyWorldFR3(SimEnvCreator):
             ),
         }
         gripper_offsets: dict[str, rcs.common.Pose] | None = {
-            self.robot_prefix_template: rcs.common.Pose(
-                rotation=FrankaHandTCPOffset()[:3, :3], translation=np.array([0.0, 0.0, 0.0])
-            )
+            self.robot_prefix_template: GRIPPER_MOUNT_OFFSETS[rcs.common.GripperType.FrankaHand]
         }
         return SimEnvCreatorConfig(
             robot_cfgs=robot_cfgs,
@@ -186,7 +185,7 @@ class EmptyWorldFR3Duo(SimEnvCreator):
 
     def config(self) -> SimEnvCreatorConfig:
         robot_cfg: SimRobotConfig[Literal[7]] = SimRobotConfig(
-            tcp_offset=GRIPPER_OFFSETS[rcs.common.GripperType("Robotiq2F85")],
+            tcp_offset=GRIPPER_TCP_OFFSETS[rcs.common.GripperType("Robotiq2F85")],
             robot_type=RobotType.FR3,
             attachment_site=rcs.ROBOTS[RobotType.FR3].attachment_site,
             kinematic_model_path=rcs.ROBOTS[RobotType.FR3].mjcf_model_path,
@@ -327,9 +326,7 @@ class EmptyWorldFR3Duo(SimEnvCreator):
                 robot_name="right",
             ),
         }
-        gripper_offset = rcs.common.Pose(
-            quaternion=np.array(self.gripper_mesh_quaternion_offset), translation=np.array([0.0, 0.0, 0.0])
-        )
+        gripper_offset = GRIPPER_MOUNT_OFFSETS[rcs.common.GripperType("Robotiq2F85")]
         return SimEnvCreatorConfig(
             robot_cfgs=robot_cfgs,
             sim_cfg=sim_cfg,
@@ -363,7 +360,7 @@ class EmptyWorldUR5e(EmptyWorldFR3):
         lead_robot_name = self.lead_robot_name(cfg)
 
         robot_cfg = cfg.robot_cfgs[lead_robot_name]
-        robot_cfg.tcp_offset = GRIPPER_OFFSETS[rcs.common.GripperType("Robotiq2F85")]
+        robot_cfg.tcp_offset = GRIPPER_TCP_OFFSETS[rcs.common.GripperType("Robotiq2F85")]
         robot_cfg.attachment_site = rcs.ROBOTS[rt].attachment_site
         robot_cfg.kinematic_model_path = rcs.ROBOTS[rt].mjcf_model_path
         robot_cfg.arm_collision_geoms = []

--- a/python/rcs/envs/configs.py
+++ b/python/rcs/envs/configs.py
@@ -4,7 +4,7 @@ from typing import ClassVar, Literal
 
 import gymnasium as gym
 import numpy as np
-from rcs._core.common import FrankaHandTCPOffset, GripperType, RobotType
+from rcs._core.common import GripperType, RobotType
 from rcs._core.sim import (
     CameraType,
     SimCameraConfig,
@@ -24,8 +24,8 @@ import rcs
 from rcs import (
     CAMERA_PATHS,
     DEFAULT_TRANSFORMS,
-    GRIPPER_TCP_OFFSETS,
     GRIPPER_MOUNT_OFFSETS,
+    GRIPPER_TCP_OFFSETS,
     OBJECT_PATHS,
     SCENE_PATHS,
 )

--- a/python/rcs/lerobot_joint_converter.py
+++ b/python/rcs/lerobot_joint_converter.py
@@ -120,7 +120,7 @@ class JointDatasetConverter:
         self.source_sql = self._build_source_sql(self.dataset_paths)
         self.video_encoding = video_encoding
 
-        self.tcp_offset = rcs.GRIPPER_OFFSETS[self.gripper_type]
+        self.tcp_offset = rcs.GRIPPER_TCP_OFFSETS[self.gripper_type]
         self.ik = rcs.common.Pin(
             rcs.ROBOTS[robot_type].mjcf_model_path,
             rcs.ROBOTS[robot_type].attachment_site,


### PR DESCRIPTION
Currently, the package root `__init__.py` contains the variable `GRIPPER_OFFSETS`, which actually indicates the TCP offset for different grippers. Propose renaming it to `GRIPPER_TCP_OFFSETS` and introduce a new variable `GRIPPER_MOUNT_OFFSETS` to clearly differentiate between the two.
FR3DUO setup is not affected, because it was using a member variable instead of using something defined in `__init__`. 
Went through existing files and updated existing `GRIPPER_OFFSETS` to the new `GRIPPER_TCP_OFFSETS`.

*Unclear:*
Existing TCP offset value for Robotiq2F85 only defines translation, not rotation (left as identity):
`common.GripperType("Robotiq2F85"): common.Pose(translation=np.array([0, 0.0, 0.1493])),`

Comparing Franka Hand TCP offset and mounting offset values, it seems that the TCP offset's rotation follows the mounting offset's:
`TCP: common.GripperType.FrankaHand: common.Pose(pose_matrix=common.FrankaHandTCPOffset())`
`Mounting: common.GripperType.FrankaHand: common.Pose(rotation=common.FrankaHandTCPOffset()[:3, :3], translation=np.array([0.0, 0.0, 0.0])),`
which means that Robotiq2F85's TCP offset needs to be updated (pseudocode) as:
`common.GripperType("Robotiq2F85"): common.Pose(rotation=robotiq2f85_mount_rotation, translation=np.array([0, 0.0, 0.1493])),`
