### PR TITLE
fix(zed): remove hidden realsense dependency

### DIFF
--- a/docs/extensions/rcs_zed.md
+++ b/docs/extensions/rcs_zed.md
@@ -19,6 +19,14 @@ pip install -ve . --no-build-isolation
 pip install -ve extensions/rcs_zed
 ```
 
+## Calibration
+
+The `default_zed(...)` helper uses the identity
+`DummyCalibrationStrategy` unless a `calibration_strategy` mapping is supplied.
+Mapping keys must match the logical camera names, and values must implement
+`rcs.camera.hw.CalibrationStrategy`. Calibration is injected explicitly so the
+ZED extension remains independent of other hardware-camera extensions.
+
 ## CLI
 
 ```shell

--- a/extensions/rcs_zed/Makefile
+++ b/extensions/rcs_zed/Makefile
@@ -1,7 +1,7 @@
 PYSRC = src/rcs_zed
 TESTSRC = tests
 TESTFILE = tests/test_zed_extension.py
-PYTHONPATH_LOCAL = ../../python:src:../rcs_realsense/src
+PYTHONPATH_LOCAL = ../../python:src
 
 pycheckformat:
 	isort --check-only ${PYSRC} ${TESTSRC}

--- a/extensions/rcs_zed/README.md
+++ b/extensions/rcs_zed/README.md
@@ -32,6 +32,29 @@ pip install -ve . --no-build-isolation
 pip install -ve extensions/rcs_zed
 ```
 
+## Calibration
+
+`default_zed(...)` is standalone and uses RCS's identity
+`DummyCalibrationStrategy` by default. To use measured extrinsics, pass one
+calibration strategy per logical camera:
+
+```python
+from rcs_zed.utils import default_zed
+
+calibration = {
+    "wrist": my_wrist_calibration,
+    "scene": my_scene_calibration,
+}
+cameras = default_zed(
+    {"wrist": "12345678", "scene": "87654321"},
+    calibration_strategy=calibration,
+)
+```
+
+Each value must implement the `rcs.camera.hw.CalibrationStrategy` protocol.
+This keeps ZED installation independent of other camera extensions and lets
+applications choose the calibration method that matches their robot setup.
+
 ## CLI
 
 ```shell

--- a/extensions/rcs_zed/pyproject.toml
+++ b/extensions/rcs_zed/pyproject.toml
@@ -11,8 +11,6 @@ license = "AGPL-3.0-or-later"
 dependencies = [
   "rcs-core>=0.7.2",
   "opencv-python~=4.10.0",
-  "pupil_apriltags",
-  "diskcache",
   "typer~=0.9",
 ]
 maintainers = [{ name = "Tobias Juelg", email = "tobias.juelg@utn.de" }]

--- a/extensions/rcs_zed/src/rcs_zed/utils.py
+++ b/extensions/rcs_zed/src/rcs_zed/utils.py
@@ -8,6 +8,14 @@ def default_zed(
     name2id: dict[str, str] | None,
     calibration_strategy: dict[str, CalibrationStrategy] | None = None,
 ) -> ZEDCameraSet | None:
+    """Create the default ZED camera set.
+
+    Args:
+        name2id: Mapping from logical camera names to ZED serial numbers.
+        calibration_strategy: Optional calibration strategy for each logical
+            camera. When omitted, ``ZEDCameraSet`` uses
+            ``DummyCalibrationStrategy``.
+    """
     if name2id is None:
         return None
     cameras = {
@@ -18,4 +26,5 @@ def default_zed(
 
 
 def default_zed_dummy_calibration(name2id: dict[str, str] | None) -> ZEDCameraSet | None:
+    """Create the default ZED camera set with dummy calibration."""
     return default_zed(name2id)

--- a/extensions/rcs_zed/src/rcs_zed/utils.py
+++ b/extensions/rcs_zed/src/rcs_zed/utils.py
@@ -1,7 +1,7 @@
-from rcs import common
 from rcs.camera.hw import CalibrationStrategy
-
 from rcs_zed.camera import ZEDCameraSet
+
+from rcs import common
 
 
 def default_zed(

--- a/extensions/rcs_zed/src/rcs_zed/utils.py
+++ b/extensions/rcs_zed/src/rcs_zed/utils.py
@@ -1,28 +1,21 @@
-import typing
-
+from rcs import common
 from rcs.camera.hw import CalibrationStrategy
-from rcs_realsense.calibration import FR3BaseArucoCalibration
+
 from rcs_zed.camera import ZEDCameraSet
 
-from rcs import common
 
-
-def default_zed(name2id: dict[str, str] | None) -> ZEDCameraSet | None:
+def default_zed(
+    name2id: dict[str, str] | None,
+    calibration_strategy: dict[str, CalibrationStrategy] | None = None,
+) -> ZEDCameraSet | None:
     if name2id is None:
         return None
     cameras = {
         name: common.BaseCameraConfig(identifier=id, resolution_width=1280, resolution_height=720, frame_rate=30)
         for name, id in name2id.items()
     }
-    calibration_strategy = {name: typing.cast(CalibrationStrategy, FR3BaseArucoCalibration(name)) for name in name2id}
     return ZEDCameraSet(cameras=cameras, calibration_strategy=calibration_strategy)
 
 
 def default_zed_dummy_calibration(name2id: dict[str, str] | None) -> ZEDCameraSet | None:
-    if name2id is None:
-        return None
-    cameras = {
-        name: common.BaseCameraConfig(identifier=id, resolution_width=1280, resolution_height=720, frame_rate=30)
-        for name, id in name2id.items()
-    }
-    return ZEDCameraSet(cameras=cameras)
+    return default_zed(name2id)

--- a/extensions/rcs_zed/tests/test_zed_extension.py
+++ b/extensions/rcs_zed/tests/test_zed_extension.py
@@ -9,11 +9,11 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "python"))
 sys.path.insert(0, str(REPO_ROOT / "extensions/rcs_zed/src"))
 
-from rcs import common  # noqa: E402
 from rcs.camera.hw import DummyCalibrationStrategy  # noqa: E402
-
 from rcs_zed.camera import ZEDCameraSet, ZEDDeviceInfo, ZEDFrameBundle  # noqa: E402
 from rcs_zed.utils import default_zed, default_zed_dummy_calibration  # noqa: E402
+
+from rcs import common  # noqa: E402
 
 
 class FakeOpenedZEDCamera:

--- a/extensions/rcs_zed/tests/test_zed_extension.py
+++ b/extensions/rcs_zed/tests/test_zed_extension.py
@@ -9,9 +9,11 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "python"))
 sys.path.insert(0, str(REPO_ROOT / "extensions/rcs_zed/src"))
 
-from rcs_zed.camera import ZEDCameraSet, ZEDDeviceInfo, ZEDFrameBundle  # noqa: E402
-
 from rcs import common  # noqa: E402
+from rcs.camera.hw import DummyCalibrationStrategy  # noqa: E402
+
+from rcs_zed.camera import ZEDCameraSet, ZEDDeviceInfo, ZEDFrameBundle  # noqa: E402
+from rcs_zed.utils import default_zed, default_zed_dummy_calibration  # noqa: E402
 
 
 class FakeOpenedZEDCamera:
@@ -34,6 +36,14 @@ class PatchZedState(TypedDict):
     devices: dict[str, ZEDDeviceInfo]
     opened: dict[str, FakeOpenedZEDCamera]
     open_calls: list[tuple[str, bool, bool, bool]]
+
+
+class FakeCalibrationStrategy:
+    def calibrate(self, samples, intrinsics, lock):
+        return True
+
+    def get_extrinsics(self):
+        return np.eye(4)
 
 
 @pytest.fixture()
@@ -163,3 +173,28 @@ def test_zed_include_right_adds_logical_right_camera_without_double_grab(patch_z
     assert left_frame.avg_timestamp == right_frame.avg_timestamp == 12.5
     assert left_frame.camera.depth is None
     assert right_frame.camera.depth is None
+
+
+def test_default_zed_uses_builtin_dummy_calibration():
+    camera_set = default_zed({"wrist": "123"})
+
+    assert camera_set is not None
+    assert isinstance(camera_set.calibration_strategy["wrist"], DummyCalibrationStrategy)
+
+
+def test_default_zed_accepts_explicit_calibration_strategy():
+    calibration = FakeCalibrationStrategy()
+    camera_set = default_zed(
+        {"wrist": "123"},
+        calibration_strategy={"wrist": calibration},
+    )
+
+    assert camera_set is not None
+    assert camera_set.calibration_strategy == {"wrist": calibration}
+
+
+def test_default_zed_dummy_calibration_remains_compatible():
+    camera_set = default_zed_dummy_calibration({"wrist": "123"})
+
+    assert camera_set is not None
+    assert isinstance(camera_set.calibration_strategy["wrist"], DummyCalibrationStrategy)


### PR DESCRIPTION
## Summary

- remove `rcs_zed`'s import-time dependency on `rcs_realsense`
- let `default_zed()` accept an explicit per-camera `CalibrationStrategy` mapping
- use `ZEDCameraSet`'s existing `DummyCalibrationStrategy` fallback when no
  strategy is supplied
- keep `default_zed_dummy_calibration()` as a backward-compatible wrapper
- remove calibration-only dependencies and the RealSense source-path injection
  that masked the packaging problem
- document the standalone calibration contract

## Motivation

`rcs_zed.utils` imported `FR3BaseArucoCalibration` from
`rcs_realsense.calibration`, but `rcs_zed` did not declare `rcs_realsense` as a
dependency. Its local Makefile added `../rcs_realsense/src` to `PYTHONPATH`, so
the extension appeared to work in a repository checkout while a standalone
installation could fail as soon as `rcs_zed.utils` was imported.

Declaring `rcs_realsense` as a dependency would make ZED users install the
unrelated `pyrealsense2` hardware stack. Moving the FR3-specific AprilTag
implementation into `rcs-core` would instead add calibration dependencies to
every core installation. Explicit strategy injection keeps the hardware
extensions independent and uses the calibration protocol RCS already exposes.

## Design

`default_zed(name2id, calibration_strategy=None)` now forwards the optional
mapping directly to `ZEDCameraSet`. The camera set already creates one
`DummyCalibrationStrategy` per camera when the mapping is omitted.

Applications that need measured extrinsics can pass any implementation of
`rcs.camera.hw.CalibrationStrategy`. Mapping keys correspond to the logical
camera names in `name2id`.

Because no code in `rcs_zed` uses `pupil_apriltags` or `diskcache` after the
cross-extension import is removed, those requirements are also removed from the
wheel metadata.

## Testing

- isolated pre-change import contract — reproduced
  `ModuleNotFoundError: No module named 'rcs_realsense'`
- isolated post-change import/behavior contract — passed; verifies no RealSense
  module is needed, default dummy calibration, custom strategy injection, and
  `None` handling
- `python -m build --wheel --outdir /tmp/rcs-zed-pr-dist
  extensions/rcs_zed` — passed
- built-wheel METADATA inspection — passed; requirements are only
  `rcs-core>=0.7.2`, `opencv-python~=4.10.0`, and `typer~=0.9`
- `isort --check-only` on changed Python files — passed
- `black --check` on changed Python files — passed
- `ruff check` on changed Python files — passed
- `python -m py_compile` on changed Python files — passed
- `git diff --check` — passed

The complete ZED extension test file was not run locally because published
`rcs-core==0.7.2` wheels are Linux x86_64-only, while this development host is
macOS arm64. The repository tests are included for the Linux CI environment.

## Compatibility and risks

The helper's original one-argument call remains valid, and
`default_zed_dummy_calibration()` retains its signature and behavior.

The intentional behavior correction is that `default_zed()` no longer silently
selects the FR3-base RealSense calibration. Callers relying on that undeclared
cross-extension behavior must pass their desired calibration strategy
explicitly. This is documented in both the extension README and the published
ZED documentation.

## Scope

This PR does not move a robot-specific AprilTag calibration into core, duplicate
that implementation in the ZED extension, or add a new shared calibration
package. Those are broader architecture choices and are not required to restore
standalone installation.

Closes #287
